### PR TITLE
Chart filtering dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'chartkick' # Use chartkick for usage graphs
 gem 'redcarpet' # Use redcarpet to convert markdown
 gem "font-awesome-rails" # Fonts
 
+gem "highcharts-rails"
 
 # User input
 gem 'trix' # Use Trix editor for activity descriptions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
       activesupport (>= 3)
     hashdiff (0.3.0)
     hashie (3.4.6)
+    highcharts-rails (5.0.7)
+      railties (>= 3.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -395,6 +397,7 @@ DEPENDENCIES
   friendly_id!
   govuk-lint
   groupdate
+  highcharts-rails
   jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,9 @@
 //= require tether.min.js
 //= require bootstrap
 //= require turbolinks
+//= require highcharts
+//= require highcharts/modules/exporting
+//= require highcharts/modules/offline-exporting
 //= require chartkick
 //= require trix
 //= require_tree .

--- a/app/assets/javascripts/switch_meter.js
+++ b/app/assets/javascripts/switch_meter.js
@@ -1,10 +1,42 @@
-$(function() {
-    $(document).on('change', '.meter-filter', function() {
-        chart_id = this.form.id.replace("-filter", "");
+$(document).on("turbolinks:load", function() {
+
+    $("#first_date_picker").datepicker(
+    {
+        dateFormat: 'DD, d MM yy',
+        altFormat: 'yy-mm-dd',
+        altField: "#first_date",
+//        minDate: -42,
+        maxDate: -1,
+        orientation: 'bottom'
+    });
+
+    $("#to_date_picker").datepicker(
+        {
+            dateFormat: 'DD, d MM yy',
+            altFormat: 'yy-mm-dd',
+            altField: "#to_date",
+//            minDate: -42,
+            maxDate: -1,
+            orientation: 'bottom'
+    });
+
+    function updateChart(el) {
+        console.log(el.id);
+        chart_id = el.form.id.replace("-filter", "");
         chart = Chartkick.charts[chart_id];
         current_source = chart.getDataSource();
-        new_source = current_source.split("?")[0] + "?" + $(this.form).serialize();
+        new_source = current_source.split("?")[0] + "?" + $(el.form).serialize();
         chart.updateData(new_source);
         chart.getChartObject().showLoading();
+    }
+    $(document).on('change', '.meter-filter', function() {
+        updateChart(this);
     });
+    $(document).on('change', '#first_date_picker', function() {
+        updateChart(this);
+    });
+    $(document).on('change', '#to_date_picker', function() {
+        updateChart(this);
+    });
+
 });

--- a/app/assets/javascripts/switch_meter.js
+++ b/app/assets/javascripts/switch_meter.js
@@ -5,5 +5,6 @@ $(function() {
         current_source = chart.getDataSource();
         new_source = current_source.split("?")[0] + "?" + $(this.form).serialize();
         chart.updateData(new_source);
+        chart.getChartObject().showLoading();
     });
 });

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -83,6 +83,7 @@ class SchoolsController < ApplicationController
 
   # GET /schools/:id/usage
   def usage
+    set_first_date
     set_to_date
     render "#{params[:period]}_usage"
   end
@@ -111,6 +112,15 @@ private
   def meter_params
     [:id, :meter_no, :meter_type, :active, :name]
   end
+
+  def set_first_date(default = Date.current - 2.days)
+    begin
+      @first_date = Date.parse params[:first_date]
+    rescue
+      @first_date = default
+    end
+  end
+
 
   def set_to_date(default = Date.current - 1.day)
     begin

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -27,7 +27,26 @@ class StatsController < ApplicationController
     ]
   end
 
+  #compare hourly usage across two dates
+  # GET /schools/:id/compare_hourly_usage?supply=:supply&meter=:meter_no&first_date=:first_date&to_date=:second_date
+  def compare_hourly_usage
+    precision = lambda { |reading| [reading[0], number_with_precision(reading[1], precision: 1)] }
+    first_date = school.hourly_usage_for_date(supply: supply,
+        date: Date.parse(params[:first_date]),
+        meter: meter
+    ).map(&precision)
+    to_date = school.hourly_usage_for_date(supply: supply,
+        date: Date.parse(params[:to_date]),
+        meter: meter
+    ).map(&precision)
+    render json: [
+        { name: params[:first_date], data: first_date },
+        { name: params[:to_date], data: to_date }
+    ]
+  end
+
   # GET /schools/:id/hourly_usage?supply=:supply&to_date=:to_date&meter=:meter_no
+  # compares hourly usage by weekday/weekend for last full week
   def hourly_usage
     week = Usage.this_week(to_date).to_a
     precision = lambda { |reading| [reading[0], number_with_precision(reading[1], precision: 1)] }

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -6,7 +6,12 @@ module SchoolsHelper
       id: "#{supply}-chart",
       xtitle: 'Date',
       ytitle: 'kWh',
-      colors: colours_for_supply(supply)
+      colors: colours_for_supply(supply),
+      library: {
+          yAxis: {
+              lineWidth: 1
+          }
+      }
     )
   end
 
@@ -17,7 +22,15 @@ module SchoolsHelper
       id: "#{supply}-chart",
       xtitle: 'Time of day',
       ytitle: 'kWh',
-      colors: colours_for_supply(supply)
+      colors: colours_for_supply(supply),
+      library: {
+          xAxis: {
+              tickmarkPlacement: 'on'
+          },
+          yAxis: {
+              lineWidth: 1
+          }
+      }
     )
   end
 

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -15,10 +15,28 @@ module SchoolsHelper
     )
   end
 
+  def compare_hourly_usage_chart(supply, first_date, to_date, meter = nil)
+    line_chart(compare_hourly_usage_school_path(supply: supply, first_date: first_date, to_date: to_date, meter: meter),
+          id: "#{supply}-chart",
+          xtitle: 'Time of day',
+          ytitle: 'kWh',
+          colors: colours_for_supply(supply),
+          library: {
+            xAxis: {
+                tickmarkPlacement: 'on'
+            },
+            yAxis: {
+                lineWidth: 1,
+                tickInterval: 2
+            }
+          }
+    )
+  end
+
+
   def hourly_usage_chart(supply, to_date, meter = nil)
     last_reading_date = @school.last_reading_date(supply, to_date)
-    line_chart(
-      hourly_usage_school_path(supply: supply, to_date: last_reading_date, meter: meter),
+    line_chart(hourly_usage_school_path(supply: supply, to_date: last_reading_date, meter: meter),
       id: "#{supply}-chart",
       xtitle: 'Time of day',
       ytitle: 'kWh',

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -28,7 +28,8 @@ module SchoolsHelper
               tickmarkPlacement: 'on'
           },
           yAxis: {
-              lineWidth: 1
+              lineWidth: 1,
+              tickInterval: 2
           }
       }
     )

--- a/app/views/schools/_electricity_cards.html.erb
+++ b/app/views/schools/_electricity_cards.html.erb
@@ -45,8 +45,10 @@
             </h3>
           </div>
           <div class="card-footer text-xs-right">
+            <% to_date = @school.last_reading_date(:electricity, Date.current)  %>
+            <% first_date = to_date.present? ? to_date - 1 : nil %>
             <%= link_to('Hourly usage',
-                          usage_school_path(@school, period: :hourly, to_date: avg_elect[0], anchor: :electricity),
+                          usage_school_path(@school, period: :hourly, first_date: first_date, to_date: to_date, anchor: :electricity),
                           class: 'btn btn-primary') unless avg_elect.nil?
               %>
           </div>

--- a/app/views/schools/_hourly_usage_panel.erb
+++ b/app/views/schools/_hourly_usage_panel.erb
@@ -1,23 +1,42 @@
 <% if @school.meters?(supply) %>
   <div class="row">
     <div class="col-md-12">
-      <% last_full_week = last_full_week(supply) %>
-      <h5>Average hourly usage between <%= l last_full_week.first %> and <%= l last_full_week.last %></h5>
-
-      Showing average <%= supply %> usage by hour of the day, for weekdays and weekends
-      <div class="pull-right">
-      Show usage for <%= form_tag "", method: :get, id: "#{supply}-chart-filter" do %>
+      <%= form_tag "", method: :get, id: "#{supply}-chart-filter" do %>
           <%= hidden_field_tag :period, "hourly" %>
-          <%= hidden_field_tag :to_date, @to_date %>
           <%= hidden_field_tag :supply, supply %>
-          <%= select_tag :meter, content_tag(:option,'All Meters',:value=>"")+options_from_collection_for_select(@school.meters_for_supply(supply), :meter_no, :display_name, selected: params[:meter]), class: "meter-filter" %>
+
+          <%= hidden_field_tag :first_date, @first_date %>
+          <%= hidden_field_tag :to_date, @to_date %>
+
+          <h5>
+            Compare hourly <%= supply %> usage
+          </h5>
+
+          <div class="row">
+            <div class="col-md-3">
+              <%= text_field_tag(:first_date_picker,
+                                 @first_date,
+                                 class: 'form-control form-control-sm'
+                  ) %>
+            </div>
+            <div class="col-md-1"><span><strong>AND</strong></span></div>
+            <div class="col-md-3">
+              <%= text_field_tag(:to_date_picker,
+                                 @to_date,
+                                 class: 'form-control form-control-sm'
+                  ) %>
+            </div>
+            <div class="col-md-2 pull-right">
+              <%= select_tag :meter, content_tag(:option,'All Meters',:value=>"")+options_from_collection_for_select(@school.meters_for_supply(supply), :meter_no, :display_name, selected: params[:meter]), class: "meter-filter" %>
+            </div>
+          </div>
       <% end %>
-      </div>
+
     </div>
   </div>
   <div class="row">
     <div class="col-md-12">
-      <%= hourly_usage_chart(supply, @to_date, params[:meter]) %>
+      <%= compare_hourly_usage_chart(supply, @first_date, @to_date, params[:meter]) %>
     </div>
   </div>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       get 'achievements'
       get 'usage'
       get 'daily_usage', to: 'stats#daily_usage'
+      get 'compare_hourly_usage', to: 'stats#compare_hourly_usage'
       get 'hourly_usage', to: 'stats#hourly_usage'
     end
   end

--- a/lib/usage.rb
+++ b/lib/usage.rb
@@ -14,6 +14,21 @@ module Usage
         .to_a
   end
 
+  def hourly_usage_for_date(supply: nil, date: nil, meter: nil)
+    datetime_range = (date.beginning_of_day..date.end_of_day)
+    self.meter_readings
+        .where(conditional_supply(supply))
+        .where(conditional_meter(meter))
+        .group_by_minute(:read_at,
+            range: datetime_range,
+            format: '%H:%M',
+            series: false
+        )
+        .sum(:value)
+        .to_a
+  end
+
+  # compare weekday/weekend hourly usage
   # hourly_usage: get average reading at the same time
   # across all meters for a given supply for a range of dates
   def hourly_usage(supply: nil, dates: nil, meter: nil)


### PR DESCRIPTION
Changes hourly usage reporting to take two dates rather than compare weekday/weekend usage.

Defaults to comparing last two days of readings.