### PR TITLE
Last 7 days

### DIFF
--- a/app/assets/javascripts/switch_meter.js
+++ b/app/assets/javascripts/switch_meter.js
@@ -1,29 +1,32 @@
 $(document).on("turbolinks:load", function() {
 
-    $("#first_date_picker").datepicker(
+    $(".first-date-picker").datepicker(
     {
         dateFormat: 'DD, d MM yy',
         altFormat: 'yy-mm-dd',
         altField: "#first_date",
 //        minDate: -42,
         maxDate: -1,
-        orientation: 'bottom'
+        orientation: 'bottom',
+        changeMonth: true,
+        changeYear: true
     });
 
-    $("#to_date_picker").datepicker(
+    $(".to-date-picker").datepicker(
         {
             dateFormat: 'DD, d MM yy',
             altFormat: 'yy-mm-dd',
             altField: "#to_date",
 //            minDate: -42,
             maxDate: -1,
-            orientation: 'bottom'
-    });
+            orientation: 'bottom',
+            changeMonth: true,
+            changeYear: true
+        });
 
 });
 
 function updateChart(el) {
-    console.log(el.id);
     chart_id = el.form.id.replace("-filter", "");
     chart = Chartkick.charts[chart_id];
     current_source = chart.getDataSource();
@@ -34,10 +37,10 @@ function updateChart(el) {
 $(document).on('change', '.meter-filter', function() {
     updateChart(this);
 });
-$(document).on('change', '#first_date_picker', function() {
+$(document).on('change', '.first-date-picker', function() {
     updateChart(this);
 });
-$(document).on('change', '#to_date_picker', function() {
+$(document).on('change', '.to-date-picker', function() {
     updateChart(this);
 });
 

--- a/app/assets/stylesheets/colours.scss
+++ b/app/assets/stylesheets/colours.scss
@@ -3,7 +3,7 @@
 //Basic colour definitions
 $yellow: #ffee8f;
 $light-orange: #ffac21;
-$dark-orange: #ee7723;
+$dark-orange: #ff4500;
 
 $light-blue: #3bc0f0;
 $dark-blue: #232b49;

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -42,8 +42,9 @@ class StatsController < ApplicationController
         meter: meter
     ).map(&precision)
     render json: [
-        { name: from.strftime('%A, %d %B %Y'), data: first_date },
-        { name: to.strftime('%A, %d %B %Y'), data: to_date }
+        { name: to.strftime('%A, %d %B %Y'), data: to_date },
+        { name: from.strftime('%A, %d %B %Y'), data: first_date }
+
     ]
   end
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -22,8 +22,8 @@ class StatsController < ApplicationController
       [this_week[index][0], day[1]]
     end
     render json: [
-      { name: 'This week', data: this_week },
-      { name: 'Last week', data: previous_week_series }
+      { name: 'Latest 7 days', data: this_week },
+      { name: 'Previous 7 days', data: previous_week_series }
     ]
   end
 

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -37,7 +37,7 @@ module SchoolsHelper
 
 
   def colours_for_supply(supply)
-    supply == "electricity" ? %w(#232b49 #3bc0f0) : %w(#ee7723 #ffee8f)
+    supply == "electricity" ? %w(#232b49 #3bc0f0) : %w(#ff4500 #ffac21)
   end
 
   # get n days average daily usage

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -36,37 +36,18 @@ module SchoolsHelper
   end
 
 
-  def hourly_usage_chart(supply, to_date, meter = nil)
-    last_reading_date = @school.last_reading_date(supply, to_date)
-    line_chart(hourly_usage_school_path(supply: supply, to_date: last_reading_date, meter: meter),
-      id: "#{supply}-chart",
-      xtitle: 'Time of day',
-      ytitle: 'kWh',
-      colors: colours_for_supply(supply),
-      library: {
-          xAxis: {
-              tickmarkPlacement: 'on'
-          },
-          yAxis: {
-              lineWidth: 1,
-              tickInterval: 2
-          }
-      }
-    )
-  end
-
   def colours_for_supply(supply)
     supply == "electricity" ? %w(#232b49 #3bc0f0) : %w(#ee7723 #ffee8f)
   end
 
-  # get last full week's average daily usage
-  def average_weekday_usage(supply)
-    last_full_week = @school.last_full_week(supply)
-    return nil unless last_full_week
-    # return the Friday's date and avarage usage
-    # average = daily usage figures, summed, divided by 5
-    [last_full_week.last, @school.daily_usage(supply: supply, dates: last_full_week)
-                                 .inject(0) { |a, e| a + e[1] } / 5
+  # get n days average daily usage
+  def average_usage(supply, window = 7)
+    last_n_days = @school.last_n_days_with_readings(supply, window)
+    return nil unless last_n_days
+    # return the latest date and average usage
+    # average = daily usage figures, summed, divided by window
+    [last_n_days.last, @school.daily_usage(supply: supply, dates: last_n_days)
+                                 .inject(0) { |a, e| a + e[1] } / window
     ]
   end
 

--- a/app/views/home/team.html.erb
+++ b/app/views/home/team.html.erb
@@ -11,7 +11,7 @@
         in developing the initial application and/or continue to be involved in the operation of the service.
       </p>
       <p>
-        We also would like to thank Resource Futures for their advice and support during the earlu stages of the
+        We also would like to thank Resource Futures for their advice and support during the early stages of the
         project.
       </p>
     </div>

--- a/app/views/schools/_daily_usage_panel.erb
+++ b/app/views/schools/_daily_usage_panel.erb
@@ -2,9 +2,10 @@
   <div class="row">
     <div class="col-md-12">
       <% last_full_week = last_full_week(supply) %>
-      <h5>Usage between <%= l last_full_week.first %> and <%= l last_full_week.last %></h5>
+      <% latest_reading_date = @school.last_reading_date(supply) %>
+      <h5>Compare usage for latest seven days with the previous week</h5>
 
-      Showing total <%= supply %> usage by day
+      Showing total <%= supply %> usage by day between <%= l latest_reading_date - 14.days %> and <%= l latest_reading_date %>
       <div class="pull-right">
       Show usage for <%= form_tag "", method: :get, id: "#{supply}-chart-filter" do %>
           <%= hidden_field_tag :period, "hourly" %>

--- a/app/views/schools/_electricity_cards.html.erb
+++ b/app/views/schools/_electricity_cards.html.erb
@@ -1,10 +1,11 @@
 <% if @school.meters?(:electricity) %>
   <section id="electricity-cards">
-    <% avg_elect = average_weekday_usage(:electricity) %>
+    <% avg_elect = average_usage(:electricity) %>
+    <% latest_reading_date = @school.last_reading_date(:electricity) %>
 
     <h4>Electricity
       <p class="text-muted pull-right">
-        <small>Week ending <%= l avg_elect[0] unless avg_elect.nil? %></small>
+        <small>Latest data <%= l latest_reading_date unless latest_reading_date.nil? %></small>
       </p>
     </h4>
 
@@ -17,7 +18,7 @@
           </div>
           <div class="card-block">
             <p>
-              Last week your school used an average of
+              Recently your school used an average of
             </p>
             <h3>
               <%= avg_elect[1].to_i unless avg_elect.nil? %></strong> kWh per day
@@ -25,10 +26,12 @@
 
           </div>
           <div class="card-footer text-xs-right">
-            <%= link_to('Daily usage',
-                        usage_school_path(@school, period: :daily, to_date: avg_elect[0], anchor: :electricity),
+            <% first_date = latest_reading_date.present? ? latest_reading_date - 1 : nil %>
+            <%= link_to('Hourly usage',
+                        usage_school_path(@school, period: :hourly, first_date: first_date, to_date: latest_reading_date, anchor: :electricity),
                         class: 'btn btn-primary') unless avg_elect.nil?
             %>
+
           </div>
         </div>
 
@@ -38,19 +41,17 @@
           </div>
           <div class="card-block">
             <p>
-              Last week your school used most energy on
+              Recently your school used most energy on
             </p>
             <h3>
               <%= day_most_usage(:electricity) %>
             </h3>
           </div>
           <div class="card-footer text-xs-right">
-            <% to_date = @school.last_reading_date(:electricity, Date.current)  %>
-            <% first_date = to_date.present? ? to_date - 1 : nil %>
-            <%= link_to('Hourly usage',
-                          usage_school_path(@school, period: :hourly, first_date: first_date, to_date: to_date, anchor: :electricity),
-                          class: 'btn btn-primary') unless avg_elect.nil?
-              %>
+            <%= link_to('Daily usage',
+                        usage_school_path(@school, period: :daily, to_date: latest_reading_date, anchor: :electricity),
+                        class: 'btn btn-primary') unless avg_elect.nil?
+            %>
           </div>
         </div>
 

--- a/app/views/schools/_gas_cards.html.erb
+++ b/app/views/schools/_gas_cards.html.erb
@@ -1,10 +1,11 @@
 <% if @school.meters?(:gas) %>
     <section id="gas-cards">
-      <% avg_gas = average_weekday_usage(:gas) %>
+      <% avg_gas = average_usage(:gas) %>
+      <% latest_reading_date = @school.last_reading_date(:gas) %>
 
       <h4>Gas
         <p class="text-muted pull-right">
-          <small>Week ending <%= l avg_gas[0] unless avg_gas .nil? %></small>
+          <small>Latest data <%= l latest_reading_date unless latest_reading_date.nil? %></small>
         </p>
       </h4>
 
@@ -18,17 +19,19 @@
 
             <div class="card-block">
               <p>
-                Last week your school used an average of
+                Recently your school used an average of
               </p>
               <h3>
                 <strong><%= avg_gas[1].to_i unless avg_gas.nil? %></strong> kWh per day
               </h3>
             </div>
             <div class="card-footer text-xs-right">
-              <%= link_to('Daily usage',
-                          usage_school_path(@school, period: :daily, to_date: avg_gas[0], anchor: :gas),
+              <% first_date = latest_reading_date.present? ? latest_reading_date - 1 : nil %>
+              <%= link_to('Hourly usage',
+                          usage_school_path(@school, period: :hourly, first_date: first_date, to_date: latest_reading_date, anchor: :gas),
                           class: 'btn btn-primary') unless avg_gas.nil?
               %>
+
             </div>
           </div>
 
@@ -39,17 +42,18 @@
 
             <div class="card-block">
               <p>
-                Last week your school used most energy on
+                Recently your school used most energy on
               </p>
               <h3>
                 <%= day_most_usage(:gas) %>
               </h3>
             </div>
             <div class="card-footer text-xs-right">
-              <%= link_to('Hourly usage',
-                          usage_school_path(@school, period: :hourly, to_date: avg_gas[0], anchor: :gas),
+              <%= link_to('Daily usage',
+                          usage_school_path(@school, period: :daily, to_date: latest_reading_date, anchor: :gas),
                           class: 'btn btn-primary') unless avg_gas.nil?
               %>
+
             </div>
           </div>
 

--- a/app/views/schools/_hourly_usage_panel.erb
+++ b/app/views/schools/_hourly_usage_panel.erb
@@ -39,6 +39,12 @@
       <%= compare_hourly_usage_chart(supply, @first_date, @to_date, params[:meter]) %>
     </div>
   </div>
+    <div class="row padded-row">
+      <div class="col-md-12">
+        EnergySparks currently holds <%= supply %> usage data for this school from <%= @school.earliest_reading_date(supply).strftime('%A, %e %B %Y') %> to <%= @school.last_reading_date(supply).strftime('%A, %e %B %Y') %>
+      </div>
+    </div>
+
 <% else %>
   <h4><%= supply.capitalize %> usage data is not available</h4>
   <p>

--- a/app/views/schools/_hourly_usage_panel.erb
+++ b/app/views/schools/_hourly_usage_panel.erb
@@ -14,16 +14,16 @@
 
           <div class="row">
             <div class="col-md-3">
-              <%= text_field_tag(:first_date_picker,
-                                 @first_date,
-                                 class: 'form-control form-control-sm'
+              <%= text_field_tag("#{supply}-first-date-picker",
+                                 @first_date.strftime('%A, %e %B %Y'),
+                                 class: 'form-control form-control-sm first-date-picker'
                   ) %>
             </div>
             <div class="col-md-1"><span><strong>AND</strong></span></div>
             <div class="col-md-3">
-              <%= text_field_tag(:to_date_picker,
-                                 @to_date,
-                                 class: 'form-control form-control-sm'
+              <%= text_field_tag("#{supply}-to-date-picker",
+                                 @to_date.strftime('%A, %e %B %Y'),
+                                 class: 'form-control form-control-sm to-date-picker'
                   ) %>
             </div>
             <div class="col-md-2 pull-right">

--- a/lib/usage.rb
+++ b/lib/usage.rb
@@ -61,6 +61,16 @@ module Usage
         .try(:to_date)
   end
 
+  def earliest_reading_date(supply)
+    self.meter_readings
+        .where(conditional_supply(supply))
+        .order(read_at: :asc)
+        .limit(1)
+        .first
+        .try(:[], 'read_at')
+        .try(:to_date)
+  end
+
   def last_n_days_with_readings(supply, window = 7, to_date = Date.current)
     latest = self.last_reading_date(supply, to_date)
     latest.nil? ? nil : latest - window.days..latest

--- a/lib/usage.rb
+++ b/lib/usage.rb
@@ -47,16 +47,23 @@ module Usage
         .to_a
   end
 
-  # last_reading: get date of the last reading on or before the given date
-  def last_reading_date(supply, to_date)
+  # Get date of the last reading up to the given date
+  # We take the start of the day because we're always interested in a full day
+  # of readings. Want to avoid showing updates when we might be loading data.
+  def last_reading_date(supply, to_date = Date.current)
     self.meter_readings
         .where(conditional_supply(supply))
-        .where('read_at <= ?', to_date.end_of_day)
+        .where('read_at <= ?', to_date.beginning_of_day)
         .order(read_at: :desc)
         .limit(1)
         .first
         .try(:[], 'read_at')
         .try(:to_date)
+  end
+
+  def last_n_days_with_readings(supply, window = 7, to_date = Date.current)
+    latest = self.last_reading_date(supply, to_date)
+    latest.nil? ? nil : latest - window.days..latest
   end
 
   # last_friday_with_readings: get date of the last friday which has readings
@@ -78,9 +85,9 @@ module Usage
   end
 
   # return day of the week with the most usage
-  # for last full week of readings
+  # for the last seven days of readings
   def day_most_usage(supply)
-    usage = daily_usage(supply: supply, dates: last_full_week(supply))
+    usage = daily_usage(supply: supply, dates: last_n_days_with_readings(supply))
     return nil unless usage
     usage.sort { |a, b| a[1] <=> b[1] }.last
   end

--- a/spec/lib/usage_spec.rb
+++ b/spec/lib/usage_spec.rb
@@ -92,7 +92,8 @@ describe 'Usage' do
       end
       it "returns the last date on/before the date specified" do
         expect(school.last_reading_date(:electricity, Date.today)).to eq Date.today - 1.days
-        expect(school.last_reading_date(:electricity, Date.today - 8.days)).to eq Date.today - 8.days
+        #should be the day before
+        expect(school.last_reading_date(:electricity, Date.today - 8.days)).to eq Date.today - 9.days
       end
     end
   end
@@ -130,6 +131,10 @@ describe 'Usage' do
       end
       it "returns an array whose second element is the value" do
         expect(school.day_most_usage(:electricity)[1]).to be_a_kind_of BigDecimal
+      end
+      it "returns the expected value" do
+        expect(school.day_most_usage(:electricity)[1].to_i).to eql(650)
+        expect(school.day_most_usage(:electricity)[0]).to eql(Date.yesterday)
       end
     end
   end


### PR DESCRIPTION
* Change school homepage to use latest date and last 7 days for key figures
* Key figures are now averages and highest usage for last 7 days, not full week/weekday
* Change links to graphs so they consistently use latest date, not last full week
* Swap links to graphs, so they're most aligned with the figures. Closes #208 
* Change the gas colours so the latest data colour is darker
* Make graphs consistently use darker colour for recent data
* Add month/year selectors to date pickers
* Daily usage chart shows last 7 days, and previous 7 days. Added dates. Closes #207 
* Fix initial date format. Closes #209 
* Add a note on date availability on hourly usage chart. Closes #222 
* Change ids on date pickes. Closes #221 
* Fix typo on team page
