### PR TITLE
Loader bug fixes

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,10 @@
 
 # Learn more: http://github.com/javan/whenever
 
+job_type :rake, "cd :path && :environment_variable=:environment :bundle_command rake :task :output"
+
+set :output, "log/jobs.log"
+
 every 1.day, :at => '6:00 am' do
   rake "loader:read_meters"
 end

--- a/lib/tasks/loader.rake
+++ b/lib/tasks/loader.rake
@@ -1,11 +1,13 @@
 namespace :loader do
   desc 'Load energy usage data for all schools'
   task read_meters: [:environment] do
+    puts Time.now
     importer = Loader::EnergyImporter.new
     School.enrolled.each do |school|
       puts "Reading meters for #{school.urn} - #{school.name}"
       importer.import_new_data_for(school)
     end
+    puts Time.now
   end
 
   task :import_school_readings, [:date] => [:environment] do |_t, args|

--- a/lib/tasks/loader.rake
+++ b/lib/tasks/loader.rake
@@ -1,13 +1,13 @@
 namespace :loader do
   desc 'Load energy usage data for all schools'
   task read_meters: [:environment] do
-    puts Time.now
+    puts Time.zone.now
     importer = Loader::EnergyImporter.new
     School.enrolled.each do |school|
       puts "Reading meters for #{school.urn} - #{school.name}"
       importer.import_new_data_for(school)
     end
-    puts Time.now
+    puts Time.zone.now
   end
 
   task :import_school_readings, [:date] => [:environment] do |_t, args|

--- a/spec/fixtures/vcr_cassettes/socrata-energy-import.yml
+++ b/spec/fixtures/vcr_cassettes/socrata-energy-import.yml
@@ -2,7 +2,121 @@
 http_interactions:
 - request:
     method: get
-    uri: https://data.bathhacked.org/resource/fqa5-b8ri.json?$limit=2000&$order=date%20ASC&$where=(mpan=%272200012581120%27%20OR%20mpan=%272200012581130%27)%20AND%20date%20%3E=%272016-12-07T00:00:00%2B00:00%27
+    uri: https://data.bathhacked.org/resource/fqa5-b8ri.json?$limit=2000&$order=date%20ASC&$where=(mpan=%272200012581120%27)%20AND%20date%20%3E=%272016-12-07T00:00:00%2B00:00%27
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      X-App-Token:
+      - L6CdbDA4jpux40RfMV59Xzvgo
+      User-Agent:
+      - soda-ruby/0.2.21 (Linux/4.4.0-53-generic; Ruby/2.3.1-p112)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 11 Dec 2016 13:57:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Socrata-Requestid:
+      - 3ix9btmo4qf9islnle6tci0cl
+      Access-Control-Allow-Origin:
+      - "*"
+      Last-Modified:
+      - Fri, 09 Dec 2016 21:09:40 UTC
+      X-Soda2-Warning:
+      - X-SODA2-Fields, X-SODA2-Types, and X-SODA2-Legacy-Types are deprecated
+      X-Soda2-Fields:
+      - '["date","_06_00","_05_30","_01_30","_02_00","_09_30","_20_30","totalunits","_19_00","_15_00","_22_00","_10_30","id","_14_30","_18_30","_04_30","_05_00","mpan","_00_30","_01_00","postcode","_21_30","_09_00","_08_30","_15_30","_16_00","_12_00","_11_30","_19_30","_03_30","_08_00","_04_00","_10_00","_22_30","_23_00","units","_07_30","_16_30","_17_00","_20_00","_13_00","_12_30","_07_00","_02_30","_03_00","_11_00","_24_00","_23_30","_06_30","_18_00","msid","_21_00","location","_14_00","_13_30","_17_30"]'
+      X-Soda2-Types:
+      - '["calendar_date","number","number","number","number","number","number","number","number","number","number","number","text","number","number","number","number","text","number","number","text","number","number","number","number","number","number","number","number","number","number","number","number","number","number","text","number","number","number","number","number","number","number","number","number","number","number","number","number","number","text","number","text","number","number","number"]'
+      X-Soda2-Legacy-Types:
+      - 'true'
+      Age:
+      - '2'
+      X-Socrata-Region:
+      - aws-eu-west-1-prod
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "date" : "2016-12-08T00:00:00",
+          "_06_00" : "8.048",
+          "_05_30" : "8.463",
+          "_01_30" : "0",
+          "_02_00" : "0",
+          "_09_30" : "0",
+          "_20_30" : "10.041",
+          "totalunits" : "141.307",
+          "_19_00" : "0",
+          "_15_00" : "0",
+          "_22_00" : "0",
+          "_10_30" : "0",
+          "id" : "1aa174ac5230e9210075f25a9bf260ef",
+          "_14_30" : "0",
+          "_18_30" : "0",
+          "_04_30" : "9.4",
+          "_05_00" : "8.292",
+          "mpan" : "2200012581120",
+          "_00_30" : "0",
+          "_01_00" : "0",
+          "postcode" : "BA2 1QR",
+          "_21_30" : "0.004",
+          "_09_00" : "0.004",
+          "_08_30" : "6.071",
+          "_15_30" : "0",
+          "_16_00" : "0",
+          "_12_00" : "8.078",
+          "_11_30" : "0",
+          "_19_30" : "0",
+          "_03_30" : "11.4",
+          "_08_00" : "5.309",
+          "_04_00" : "11.18",
+          "_10_00" : "0",
+          "_22_30" : "0",
+          "_23_00" : "0",
+          "units" : "kWh",
+          "_07_30" : "5.324",
+          "_16_30" : "0",
+          "_17_00" : "0",
+          "_20_00" : "9.954",
+          "_13_00" : "6.727",
+          "_12_30" : "8.079",
+          "_07_00" : "5.317",
+          "_02_30" : "0",
+          "_03_00" : "0",
+          "_11_00" : "0",
+          "_24_00" : "0",
+          "_23_30" : "0",
+          "_06_30" : "6.623",
+          "_18_00" : "0",
+          "msid" : "E12BG09121",
+          "_21_00" : "8.289",
+          "location" : "Twerton Infant School Electricity Supply",
+          "_14_00" : "0.003",
+          "_13_30" : "4.701",
+          "_17_30" : "0"
+        }
+         ]
+    http_version: 
+  recorded_at: Sun, 11 Dec 2016 13:57:11 GMT
+- request:
+    method: get
+    uri: https://data.bathhacked.org/resource/fqa5-b8ri.json?$limit=2000&$order=date%20ASC&$where=(mpan=%272200012581130%27)%20AND%20date%20%3E=%272016-12-07T00:00:00%2B00:00%27
     body:
       encoding: UTF-8
       string: 'null'
@@ -111,7 +225,177 @@ http_interactions:
           "_13_30" : "7.198",
           "_17_30" : "6.792"
         }
-        , {
+         ]
+    http_version:
+  recorded_at: Sun, 11 Dec 2016 13:57:11 GMT
+- request:
+    method: get
+    uri: https://data.bathhacked.org/resource/fqa5-b8ri.json?$limit=2000&$order=date%20ASC&$where=(mpan=%272200012581130%27)
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      X-App-Token:
+      - L6CdbDA4jpux40RfMV59Xzvgo
+      User-Agent:
+      - soda-ruby/0.2.21 (Linux/4.4.0-53-generic; Ruby/2.3.1-p112)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 11 Dec 2016 13:57:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Socrata-Requestid:
+      - 3ix9btmo4qf9islnle6tci0cl
+      Access-Control-Allow-Origin:
+      - "*"
+      Last-Modified:
+      - Fri, 09 Dec 2016 21:09:40 UTC
+      X-Soda2-Warning:
+      - X-SODA2-Fields, X-SODA2-Types, and X-SODA2-Legacy-Types are deprecated
+      X-Soda2-Fields:
+      - '["date","_06_00","_05_30","_01_30","_02_00","_09_30","_20_30","totalunits","_19_00","_15_00","_22_00","_10_30","id","_14_30","_18_30","_04_30","_05_00","mpan","_00_30","_01_00","postcode","_21_30","_09_00","_08_30","_15_30","_16_00","_12_00","_11_30","_19_30","_03_30","_08_00","_04_00","_10_00","_22_30","_23_00","units","_07_30","_16_30","_17_00","_20_00","_13_00","_12_30","_07_00","_02_30","_03_00","_11_00","_24_00","_23_30","_06_30","_18_00","msid","_21_00","location","_14_00","_13_30","_17_30"]'
+      X-Soda2-Types:
+      - '["calendar_date","number","number","number","number","number","number","number","number","number","number","number","text","number","number","number","number","text","number","number","text","number","number","number","number","number","number","number","number","number","number","number","number","number","number","text","number","number","number","number","number","number","number","number","number","number","number","number","number","number","text","number","text","number","number","number"]'
+      X-Soda2-Legacy-Types:
+      - 'true'
+      Age:
+      - '2'
+      X-Socrata-Region:
+      - aws-eu-west-1-prod
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "date" : "2016-12-08T00:00:00",
+          "_06_00" : "1.193",
+          "_05_30" : "0.918",
+          "_01_30" : "0.863",
+          "_02_00" : "1.003",
+          "_09_30" : "6.335",
+          "_20_30" : "1.76",
+          "totalunits" : "165.342",
+          "_19_00" : "2.171",
+          "_15_00" : "6.154",
+          "_22_00" : "1.183",
+          "_10_30" : "7.858",
+          "id" : "b748167021bd07e711cdd59e6287cc9a",
+          "_14_30" : "5.652",
+          "_18_30" : "3.828",
+          "_04_30" : "0.819",
+          "_05_00" : "0.849",
+          "mpan" : "2200012581130",
+          "_00_30" : "0.893",
+          "_01_00" : "0.838",
+          "postcode" : "BA2 1QR",
+          "_21_30" : "1.396",
+          "_09_00" : "4.827",
+          "_08_30" : "4.957",
+          "_15_30" : "5.878",
+          "_16_00" : "5.011",
+          "_12_00" : "8.151",
+          "_11_30" : "6.135",
+          "_19_30" : "1.563",
+          "_03_30" : "0.875",
+          "_08_00" : "3.571",
+          "_04_00" : "0.814",
+          "_10_00" : "6.988",
+          "_22_30" : "1.095",
+          "_23_00" : "0.905",
+          "units" : "kWh",
+          "_07_30" : "1.914",
+          "_16_30" : "5.078",
+          "_17_00" : "5.504",
+          "_20_00" : "1.709",
+          "_13_00" : "8.713",
+          "_12_30" : "8.94",
+          "_07_00" : "1.725",
+          "_02_30" : "0.855",
+          "_03_00" : "0.838",
+          "_11_00" : "5.846",
+          "_24_00" : "0.913",
+          "_23_30" : "1.072",
+          "_06_30" : "2.052",
+          "_18_00" : "4.829",
+          "msid" : "E12BG09126",
+          "_21_00" : "1.537",
+          "location" : "Twerton Infant School Electricity Supply",
+          "_14_00" : "5.344",
+          "_13_30" : "7.198",
+          "_17_30" : "6.792"
+        }
+         ]
+    http_version:
+  recorded_at: Sun, 11 Dec 2016 13:57:11 GMT
+- request:
+    method: get
+    uri: https://data.bathhacked.org/resource/fqa5-b8ri.json?$limit=2000&$order=date%20ASC&$where=(mpan=%272200012581120%27)
+    body:
+      encoding: UTF-8
+      string: 'null'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      X-App-Token:
+      - L6CdbDA4jpux40RfMV59Xzvgo
+      User-Agent:
+      - soda-ruby/0.2.21 (Linux/4.4.0-53-generic; Ruby/2.3.1-p112)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sun, 11 Dec 2016 13:57:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Socrata-Requestid:
+      - 3ix9btmo4qf9islnle6tci0cl
+      Access-Control-Allow-Origin:
+      - "*"
+      Last-Modified:
+      - Fri, 09 Dec 2016 21:09:40 UTC
+      X-Soda2-Warning:
+      - X-SODA2-Fields, X-SODA2-Types, and X-SODA2-Legacy-Types are deprecated
+      X-Soda2-Fields:
+      - '["date","_06_00","_05_30","_01_30","_02_00","_09_30","_20_30","totalunits","_19_00","_15_00","_22_00","_10_30","id","_14_30","_18_30","_04_30","_05_00","mpan","_00_30","_01_00","postcode","_21_30","_09_00","_08_30","_15_30","_16_00","_12_00","_11_30","_19_30","_03_30","_08_00","_04_00","_10_00","_22_30","_23_00","units","_07_30","_16_30","_17_00","_20_00","_13_00","_12_30","_07_00","_02_30","_03_00","_11_00","_24_00","_23_30","_06_30","_18_00","msid","_21_00","location","_14_00","_13_30","_17_30"]'
+      X-Soda2-Types:
+      - '["calendar_date","number","number","number","number","number","number","number","number","number","number","number","text","number","number","number","number","text","number","number","text","number","number","number","number","number","number","number","number","number","number","number","number","number","number","text","number","number","number","number","number","number","number","number","number","number","number","number","number","number","text","number","text","number","number","number"]'
+      X-Soda2-Legacy-Types:
+      - 'true'
+      Age:
+      - '2'
+      X-Socrata-Region:
+      - aws-eu-west-1-prod
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
           "date" : "2016-12-08T00:00:00",
           "_06_00" : "8.048",
           "_05_30" : "8.463",
@@ -170,6 +454,6 @@ http_interactions:
           "_17_30" : "0"
         }
          ]
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 Dec 2016 13:57:11 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes a performance bug in the loader caused by not checking whether meters are active, and using the latest date across all meters, not per meter.

Now queries for each meter individually. This is more requests to Socrata, but each one should retrieve less data and be quicker to process.