### PR TITLE
Internet Explorer chart rendering was broken

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,7 +24,6 @@
 //= require activity_types
 //= require calendars
 //= require data_explorer
-//= require open_tab
 //= require schools
 //= require users
 

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -66,9 +66,6 @@ var commonChartOptions = {
 }
 
 
-
-
-
 function barColumnLine(d, c, chartIndex, seriesData, yAxisLabel, chartType) {
   var subChartType = d.chart1_subtype;
   console.log('bar or column or line ' + subChartType);

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -66,6 +66,9 @@ var commonChartOptions = {
 }
 
 
+
+
+
 function barColumnLine(d, c, chartIndex, seriesData, yAxisLabel, chartType) {
   var subChartType = d.chart1_subtype;
   console.log('bar or column or line ' + subChartType);
@@ -138,6 +141,13 @@ function barColumnLine(d, c, chartIndex, seriesData, yAxisLabel, chartType) {
 }
 
 function isAStringAndStartsWith(thing, startingWith) {
+  // IE Polyfill for startsWith
+  if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(search, pos) {
+      return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
+    };
+  }
+
   (typeof thing === 'string' || thing instanceof String) && thing.startsWith('Energy')
 }
 

--- a/app/assets/javascripts/open_tab.js
+++ b/app/assets/javascripts/open_tab.js
@@ -1,7 +1,0 @@
-"use strict"
-
-$(document).ready(function() {
-  if (document.location.hash) {
-    $(`.nav-tabs a[href="${document.location.hash}"]`).tab('show');
-  }
-});

--- a/app/views/activity_types/show.html.erb
+++ b/app/views/activity_types/show.html.erb
@@ -35,7 +35,7 @@
       <% else %>
         <h5>Complete this activity at your school</h5>
         <p>This activity will score your school <strong><%= @activity_type.score %></strong> points!</p>
-        <p><%= pluralize(@school_count, 'school has', 'schools have') %> scored points for this activity </strong>.</p>
+        <p><strong><%= pluralize(@school_count, 'school has', 'schools have') %> scored points for this activity </strong>.</p>
         <% if current_user.try(:school_admin_or_user?) %>
           <%= link_to 'Record this activity', new_school_activity_path(current_user.school, activity_type_id: @activity_type.id), class: 'btn btn-primary' %>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>
+    <%= yield :charts_js %>
   </body>
-  <%= yield :charts_js %>
+
 </html>

--- a/app/views/schools/_meter_cards.html.erb
+++ b/app/views/schools/_meter_cards.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="card-body">
             <p>Based on our latest data, your school used an average of</p>
-            <h2><%= avg_usage_of_utlity_type[1].to_i unless avg_usage_of_utlity_type.nil? %></strong> kWh per day </h2>
+            <h2><strong><%= avg_usage_of_utlity_type[1].to_i unless avg_usage_of_utlity_type.nil? %></strong> kWh per day </h2>
             <p class="text-muted"> Since <%= kid_date_no_year(avg_usage_of_utlity_type[0] - 7.days) %></p>
           </div>
           <div class="card-footer text-right">

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -37,7 +37,7 @@
 
         <%= link_to('Calendar', calendar_path(@school.calendar), class: 'btn btn-primary btn-sm') if can? :manage, @school.calendar %>
       </p>
-     </div>
+    </div>
   </div>
   <div class="row">
 
@@ -51,5 +51,6 @@
           <h4>This school has no gas meters configured in Energy Sparks</h4>
         </section>
       <% end %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
To fix it:
 * Close any open tags (like Strongs - typos)
 * Move chartkick JS in to body instead of being between body & html
 tags
 * polyfill startsWith as not supported in IE
 * Remove unused tab code with back ticks which IE didn't like