### PR TITLE
Ensure prefixer works post folder name, not for files

### DIFF
--- a/lib/amr/importer.rb
+++ b/lib/amr/importer.rb
@@ -29,7 +29,7 @@ module Amr
     end
 
     def get_array_of_files_in_bucket_with_prefix
-      contents = @s3_client.list_objects(bucket: @bucket, prefix: @config.s3_folder).contents
+      contents = @s3_client.list_objects(bucket: @bucket, prefix: "#{@config.s3_folder}/").contents
       # Folders come back with size 0 and we don't need those
       contents.select { |record| !record.size.zero? }.map { |record| File.basename(record.key) }
     end


### PR DESCRIPTION
Now we have sheffield and sheffield-gas the prefix bucket checker was picking up stuff in sheffield-gas when it shouldn't have...