### PR TITLE
Switching calendar event date picker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'statsample', git: 'https://github.com/SciRuby/statsample', branch: 'master'
 
 # Assets
 gem 'jquery-rails' # Use jquery as the JavaScript library
-gem 'jquery-ui-rails' # Use jquery UI for datepickers
+# gem 'jquery-ui-rails' # Use jquery UI for datepickers
 gem 'sass-rails'# Use SCSS for stylesheets
 gem 'uglifier' # Use Uglifier as compressor for JavaScript assets
 gem 'bootstrap4-datetime-picker-rails' # For tempus dominus date picker

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem 'statsample', git: 'https://github.com/SciRuby/statsample', branch: 'master'
 
 # Assets
 gem 'jquery-rails' # Use jquery as the JavaScript library
-# gem 'jquery-ui-rails' # Use jquery UI for datepickers
 gem 'sass-rails'# Use SCSS for stylesheets
 gem 'uglifier' # Use Uglifier as compressor for JavaScript assets
 gem 'bootstrap4-datetime-picker-rails' # For tempus dominus date picker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,8 +282,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (6.0.1)
-      railties (>= 3.2.16)
     json (2.1.0)
     jwt (2.1.0)
     listen (3.0.8)
@@ -621,7 +619,6 @@ DEPENDENCIES
   handlebars_assets
   jbuilder (~> 2.5)
   jquery-rails
-  jquery-ui-rails
   listen (~> 3.0.5)
   lograge
   mailgun_rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,7 +3,6 @@
 
 //= require jquery
 //= require jquery_ujs
-//= require jquery-ui/widgets/datepicker
 
 // Popper is a requirement for bootstrap and is included either in the bootstrap gem
 // or as a dependency

--- a/app/assets/javascripts/calendar_year_view.js
+++ b/app/assets/javascripts/calendar_year_view.js
@@ -32,9 +32,7 @@ $(document).ready(function() {
       }
       $('#event-modal input[name="event-index"]').val(event ? event.id : '');
       $('#event-modal input[name="calendar_event[start_date]"]').val(startDate ? startDate.toLocaleDateString("en-GB") : '');
-      setUpDatePickers("calendar_event[start_date]");
       $('#event-modal input[name="calendar_event[end_date]"]').val(endDate ? endDate.toLocaleDateString("en-GB") : '');
-      setUpDatePickers("calendar_event[end_date]");
 
       $('#event-modal').modal();
     }

--- a/app/assets/javascripts/calendar_year_view.js
+++ b/app/assets/javascripts/calendar_year_view.js
@@ -3,14 +3,6 @@
 $(document).ready(function() {
   if ($("#calendar").length) {
 
-    function setUpDatePickers(input_field_name) {
-      $('#event-modal input[name="' + input_field_name + '"]').datepicker({
-        dateFormat: 'dd/mm/yy',
-        altFormat: 'yy-mm-dd',
-        orientation: 'bottom'
-      });
-    }
-
     function editEvent(event) {
 
       var startDate = null;

--- a/app/assets/javascripts/calendars.js
+++ b/app/assets/javascripts/calendars.js
@@ -1,16 +1,27 @@
 "use strict"
 
 $(document).ready(function() {
-  $(".term_datepicker").datepicker({
-    dateFormat: 'dd/mm/yy',
-    altFormat: 'yy-mm-dd',
-    orientation: 'bottom'
-  });
-  // set altField from data attribute
-  $(".term_datepicker").each(function() {
-    const altfield = $(this).data("altfield");
-    $(this).datepicker("option", "altField", altfield);
-  });
+  if ($("form.calendar_event_form").length) {
+
+    function setUpDatePicker(date_type) {
+      var $datePickerDiv = $('div#' + date_type + '_date_picker_field');
+
+      if ($datePickerDiv.length) {
+        var calendar_event_date_value = $('input#calendar_event_' + date_type + '_date').val();
+        var defaultDate = $datePickerDiv.data('default-date');
+        var momentDate = moment(calendar_event_date_value);
+        console.log(momentDate);
+        $datePickerDiv.datetimepicker({
+          format: 'DD/MM/YYYY',
+          date: momentDate,
+          allowInputToggle: true
+        });
+      }
+    }
+
+    setUpDatePicker('start');
+    setUpDatePicker('end');
+  }
 
   var calendar_event_date_value = $('#calendar_event_holder .datetimepicker-input').val();
   $('#calendar_event_holder').datetimepicker({

--- a/app/assets/javascripts/calendars.js
+++ b/app/assets/javascripts/calendars.js
@@ -9,8 +9,8 @@ $(document).ready(function() {
       if ($datePickerDiv.length) {
         var calendar_event_date_value = $('input#calendar_event_' + date_type + '_date').val();
         var defaultDate = $datePickerDiv.data('default-date');
-        var momentDate = moment(calendar_event_date_value);
-        console.log(momentDate);
+        var momentDate = moment(calendar_event_date_value, 'DD/MM/YYYY');
+
         $datePickerDiv.datetimepicker({
           format: 'DD/MM/YYYY',
           date: momentDate,
@@ -21,12 +21,13 @@ $(document).ready(function() {
 
     setUpDatePicker('start');
     setUpDatePicker('end');
-  }
 
-  var calendar_event_date_value = $('#calendar_event_holder .datetimepicker-input').val();
-  $('#calendar_event_holder').datetimepicker({
-    format: 'DD/MM/YYYY',
-    allowInputToggle: true,
-    date: moment(calendar_event_date_value)
-  });
+    var calendar_event_date_value = $('#calendar_event_holder .datetimepicker-input').val();
+
+    $('#calendar_event_holder').datetimepicker({
+      format: 'DD/MM/YYYY',
+      allowInputToggle: true,
+      date: moment(calendar_event_date_value, 'DD/MM/YYYY')
+    });
+  }
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,5 @@
 /*
  *
- *= require jquery-ui/datepicker
  *= require trix
  */
 @import "bootstrap";

--- a/app/views/calendars/_event_modal.html.erb
+++ b/app/views/calendars/_event_modal.html.erb
@@ -7,11 +7,11 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <%= form_for([@calendar, CalendarEvent.last], class:"form-horizontal", html: { id: 'event_form', calendar_id: @calendar.id} ) do |f| %>
+      <%= form_for([@calendar, CalendarEvent.last], html: { id: 'event_form', calendar_id: @calendar.id, class:"form-horizontal calendar_event_form"} ) do |f| %>
       <%= f.hidden_field :calendar_id, value: @calendar.id %>
 
       <div class="modal-body">
-        <input name="event-index" type="hidden">     
+        <input name="event-index" type="hidden">
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: 'form-control' %>
@@ -19,16 +19,45 @@
         </div>
         <div class="form-group">
           <label for="inputAddress">Event Type</label>
-          <%= f.select   :calendar_event_type_id, options_from_collection_for_select(CalendarEventType.all, 'id', 'display_title',nil) ,{}, { class: 'form-control' } %>
+          <%= f.select :calendar_event_type_id, options_from_collection_for_select(CalendarEventType.all, 'id', 'display_title',nil) ,{}, { class: 'form-control' } %>
         </div>
-        <div class="form-row">
-          <div class="form-group col-md-6">
-          <%= f.label :start_date %>
-          <%= f.text_field :start_date, class: 'form-control' %>
+
+        <div class="row">
+          <div class="col">
+            <div class="form-group">
+              <%= f.label :start_date %>
+              <div class="input-group">
+                <div class="input-group date" id="start_date_picker_field" data-target-input="nearest">
+                 <%= f.text_field(:start_date,
+                    { class: 'form-control datetimepicker-input',
+                      data: { target: "#start_date_picker_field" },
+                      value: f.object.start_date.try(:strftime, "%d/%m/%Y")
+                    }
+                  ) %>
+                  <div class="input-group-append" data-target="#start_date_picker_field" data-toggle="datetimepicker">
+                    <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="form-group col-md-6">
-          <%= f.label :end_date %>
-          <%= f.text_field :end_date, class: 'form-control' %>
+          <div class="col">
+            <div class="form-group">
+              <%= f.label :end_date %>
+                <div class="input-group">
+                  <div class="input-group date" id="end_date_picker_field" data-target-input="nearest">
+                   <%= f.text_field(:end_date,
+                      { class: 'form-control datetimepicker-input',
+                        data: { target: "#end_date_picker_field" },
+                        value: f.object.end_date.try(:strftime, "%d/%m/%Y")
+                      }
+                    ) %>
+                    <div class="input-group-append" data-target="#end_date_picker_field" data-toggle="datetimepicker">
+                      <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                    </div>
+                  </div>
+                </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/calendars/calendar_events/_form.html.erb
+++ b/app/views/calendars/calendar_events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for([calendar, calendar_event]) do |f| %>
+<%= form_for([calendar, calendar_event], html: { class: 'calendar_event_form'}) do |f| %>
   <div class="form-group">
     <%= f.label :title %>
     <%= f.text_field :title, class: 'form-control' %>
@@ -15,30 +15,43 @@
   </div>
 
   <div class="form-group row">
-
     <div class="col">
-      <%= f.label :start_date %>
-      <%= text_field_tag("start_date_picker_#{f.index}",
-                f.object.start_date.try(:strftime, "%d/%m/%Y"),
-                placeholder: 'select date',
-                class: 'form-control term_datepicker',
-                data: { altfield: "#calendar_event_start_date" }
-              ) %>
-      <%= f.hidden_field :start_date %>
+      <div class="form-group">
+        <%= f.label :start_date %>
+        <div class="input-group">
+          <div class="input-group date" id="start_date_picker_field" data-target-input="nearest">
+           <%= f.text_field(:start_date,
+              { class: 'form-control datetimepicker-input',
+                data: { target: "#start_date_picker_field" },
+                value: f.object.start_date.try(:strftime, "%d/%m/%Y")
+              }
+            ) %>
+            <div class="input-group-append" data-target="#start_date_picker_field" data-toggle="datetimepicker">
+              <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <div class="col">
-      <%= f.label :end_date %>
-      <%= text_field_tag("end_date_picker_#{f.index}".to_sym,
-                        f.object.end_date.try(:strftime, "%d/%m/%Y"),
-                        placeholder: 'select date',
-                        class: 'form-control term_datepicker',
-                        data: { altfield: "#calendar_event_end_date" }
-                      ) %>
-      <%= f.hidden_field :end_date %>
-
+      <div class="form-group">
+        <%= f.label :end_date %>
+          <div class="input-group">
+            <div class="input-group date" id="end_date_picker_field" data-target-input="nearest">
+             <%= f.text_field(:end_date,
+                { class: 'form-control datetimepicker-input',
+                  data: { target: "#end_date_picker_field" },
+                  value: f.object.end_date.try(:strftime, "%d/%m/%Y")
+                }
+              ) %>
+              <div class="input-group-append" data-target="#end_date_picker_field" data-toggle="datetimepicker">
+                <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+              </div>
+            </div>
+          </div>
+      </div>
     </div>
   </div>
-    <%= f.submit class: 'btn btn-primary' %>
-    <%= link_to 'Back', :back, class: 'btn btn-secondary' %>
-
+  <%= f.submit class: 'btn btn-primary' %>
+  <%= link_to 'Back', :back, class: 'btn btn-secondary' %>
 <% end %>


### PR DESCRIPTION
This is removing the old school data picker and using the current one on the calendar event pages - further refactoring could take place when we get the chance.