### PR TITLE
New taxonomy structure with test patch

### DIFF
--- a/spec/services/activity_type_filter_spec.rb
+++ b/spec/services/activity_type_filter_spec.rb
@@ -164,11 +164,12 @@ RSpec.describe ActivityTypeFilter, type: :service do
       it { is_expected.to match_array([]) }
     end
 
-    context 'when nothing is selected, ordering the custom activity type last' do
+    context 'when nothing is selected' do
       let(:query){{}}
-      it { is_expected.to eq([activity_type_2, activity_type_3, activity_type_1]) }
+
+      it 'should have custom activity type last' do
+        expect(subject.last).to eq activity_type_1
+      end
     end
-
   end
-
 end


### PR DESCRIPTION
Running ```bundle exec rspec ./spec/services/activity_type_filter_spec.rb --seed 12201``` caused a test to fail which checked the order of the array of three elements, when it only needed to check that the last one as the custom one. I've amended the test, but am interested to know whether a) I'm right in my assumption b) The rspec style is ok bearing in mind the other tests in this class :)