### PR TITLE
Colour was a 8 digit hex - which included transparency

### DIFF
--- a/app/assets/stylesheets/colours.scss
+++ b/app/assets/stylesheets/colours.scss
@@ -7,7 +7,7 @@ $dark-orange: #ff4500;  /* almost red; rgb(255,69,0) */
 
 $light-blue: #3bc0f0;   /* cyanish rgb(59,192,240) */
 
-$light-blue-links: #007bffcc;
+$light-blue-links: #007bff;
 $dark-blue: #232b49;    /* very dark blue rgb(35,43,73) */
 
 $green: #5cb85c;        /* nice green rgb(92,184,92) */


### PR DESCRIPTION
This caused a deprecation warning, so convert to normal 6 digit colour