### PR TITLE
Switch to using just aggregate for a validated meter collection

### DIFF
--- a/app/services/aggregate_school_service.rb
+++ b/app/services/aggregate_school_service.rb
@@ -8,7 +8,7 @@ class AggregateSchoolService
   def aggregate_school
     Rails.cache.fetch(cache_key, expires_in: 1.day) do
       meter_collection = AmrValidatedMeterCollection.new(@school)
-      AggregateDataService.new(meter_collection).validate_and_aggregate_meter_data
+      AggregateDataService.new(meter_collection).aggregate_heat_and_electricity_meters
       # Pre-warm environment caches
       meter_collection.holidays
       meter_collection.temperatures


### PR DESCRIPTION
Previously the validated meter collection retrieved from the database didn't know what the meter attributes would be for a meter, they were only added during the validation process.

Now the meter attributes are accessible from the normal meter, we don't need to re-validate the readings (which are already retrieved from the DB validated). 