### PR TITLE
Latest analytics - enable remaining alerts (apart from impending holidays alert)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/PhilipTB/energy-sparks_analytics.git', tag: '0.43.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/PhilipTB/energy-sparks_analytics.git', tag: '0.44.0'
 #gem 'energy-sparks_analytics', path: '../analytics-for-energy-sparks'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/PhilipTB/energy-sparks_analytics.git
-  revision: 0cde88368b301c2a4d06ecc7caf940f6c59d2066
-  tag: 0.43.3
+  revision: b5a7e718f91f43bb72ec3ad9050ab165104551b0
+  tag: 0.44.0
   specs:
-    energy-sparks_analytics (0.43.3.pre.includes.pre.bishop.pre.sutton.pre.patch.pre.and.pre.significant.pre.figures.pre.walkley.pre.fix)
+    energy-sparks_analytics (0.44.0.pre.new.pre.solar.pre.pv.pre.equivalences.pre.bug.pre.fixes)
       activesupport (~> 6.0.0.rc1)
       benchmark-memory (~> 0.1.2)
       chroma (~> 0.2.0)

--- a/lib/tasks/deployment/20190514130807_enable_remaining_alerts.rake
+++ b/lib/tasks/deployment/20190514130807_enable_remaining_alerts.rake
@@ -1,0 +1,23 @@
+namespace :after_party do
+  desc 'Deployment task: enable_remaining_alerts'
+  task enable_remaining_alerts: :environment do
+    puts "Running deploy task 'enable_remaining_alerts'"
+
+    # Put your task implementation HERE.
+    ActiveRecord::Base.transaction do
+      %w(
+        AlertWeekendGasConsumptionShortTerm
+        AlertHeatingOnOff
+        AlertHotWaterEfficiency
+        AlertThermostaticControl
+      ).each do |class_name|
+        puts "Enabling variables for #{class_name}"
+        AlertType.find_by!(class_name: class_name).update!(has_variables: true)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20190514130807'
+  end
+end

--- a/lib/tasks/deployment/20190514131048_add_alerts_non_school_days_heating.rake
+++ b/lib/tasks/deployment/20190514131048_add_alerts_non_school_days_heating.rake
@@ -1,0 +1,23 @@
+namespace :after_party do
+  desc 'Deployment task: add_alerts_non_school_days_heating'
+  task add_alerts_non_school_days_heating: :environment do
+    puts "Running deploy task 'add_alerts_non_school_days_heating'"
+
+    # Put your task implementation HERE.
+    AlertType.create(
+      fuel_type: :gas,
+      sub_category: :heating,
+      frequency: :weekly,
+      title: "Heating on on non school days",
+      description: "Heating on on non school days",
+      class_name: 'AlertHeatingOnNonSchoolDays',
+      show_ratings: true,
+      has_variables: true,
+      source: 'analytics'
+    )
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20190514131048'
+  end
+end


### PR DESCRIPTION
Latest analytics release including new Solar PV (not yet implemented), Equivalences (not yet complete) and various other patches for aggregation and alert generation.

This is on test at the moment.