### PR TITLE
Split font loading for Safari

### DIFF
--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -16,7 +16,9 @@
 
 <%= stylesheet_link_tag "//cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/css/select2.min.css" %>
 <%= stylesheet_link_tag "//cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" %>
-<%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Open+Sans|Quicksand:300,500,700&display=swap" %>
+<%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Open+Sans|Quicksand:300&display=swap" %>
+<%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Open+Sans|Quicksand:500&display=swap" %>
+<%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Open+Sans|Quicksand:700&display=swap" %>
 
 <%= stylesheet_link_tag    'application', media: 'all' %>
 <%= stylesheet_pack_tag    'stylesheets' %>


### PR DESCRIPTION
Bug related to font loading on Safari when fonts are applied to the whole page: https://github.com/google/fonts/issues/2155

Not entirely sure about this fix. Extra http requests, but they probably have decent caching and aren't on our servers. Only affects a handful of safari versions but affects the second most recent one.