### PR TITLE
Patch for removing all upsert and fixing order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'rack-attack'
 # Database/Data
 gem 'pg', '1.0.0' # Use postgresql as the database for Active Record
 gem 'after_party' # load data after deploy
-gem 'upsert', git: 'https://github.com/seamusabshere/upsert.git'
 gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,12 +40,6 @@ GIT
       rubyvis (~> 0.6.1)
       spreadsheet (~> 1.1)
 
-GIT
-  remote: https://github.com/seamusabshere/upsert.git
-  revision: b4a198be9253eefc3e25d88e10c21d9acb9ab6d4
-  specs:
-    upsert (3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -665,7 +659,6 @@ DEPENDENCIES
   twilio-ruby
   tzinfo-data
   uglifier
-  upsert!
   web-console
   webdrivers
   webmock

--- a/app/services/amr/analytics_unvalidated_meter_collection_factory.rb
+++ b/app/services/amr/analytics_unvalidated_meter_collection_factory.rb
@@ -73,7 +73,7 @@ module Amr
 
       hash_of_date_formats = AmrDataFeedConfig.pluck(:id, :date_format).to_h
 
-      AmrDataFeedReading.where(meter_id: active_record_meter.id).each do |reading|
+      AmrDataFeedReading.order(created_at: :asc).where(meter_id: active_record_meter.id).each do |reading|
         add_reading_if_valid(active_record_meter, dashboard_meter, reading, hash_of_date_formats)
       end
 

--- a/app/services/amr/upsert_validated_readings_for_a_meter.rb
+++ b/app/services/amr/upsert_validated_readings_for_a_meter.rb
@@ -12,11 +12,9 @@ module Amr
 
       validated_amr_data = amr_data.delete_if {|_reading_date, one_day_read| is_nan?(one_day_read) }
 
-      Upsert.batch(AmrValidatedReading.connection, AmrValidatedReading.table_name) do |upsert|
-        validated_amr_data.values.each do |one_day_read|
-          upsert_from_one_day_reading(@dashboard_meter.external_meter_id, upsert, one_day_read)
-        end
-      end
+      result = AmrValidatedReading.upsert_all(convert_to_hash(validated_amr_data), unique_by: [:meter_id, :reading_date])
+      result.rows.flatten.size
+
       Rails.logger.info "Upserted: #{@dashboard_meter}"
       @dashboard_meter.amr_data = validated_amr_data
       @dashboard_meter
@@ -24,16 +22,18 @@ module Amr
 
   private
 
-    def upsert_from_one_day_reading(meter_id, upsert, one_day_reading)
-      upsert.row({ meter_id: meter_id, reading_date: one_day_reading.date },
-        meter_id: meter_id,
+    def convert_to_hash(validated_amr_data)
+      validated_amr_data.values.map do |one_day_reading|
+      {
+        meter_id: @dashboard_meter.external_meter_id,
         reading_date: one_day_reading.date,
         kwh_data_x48: one_day_reading.kwh_data_x48,
         one_day_kwh: one_day_reading.one_day_kwh,
         substitute_date: one_day_reading.substitute_date,
         status: one_day_reading.type,
         upload_datetime: one_day_reading.upload_datetime
-      )
+      }
+      end
     end
 
     def is_nan?(one_day_reading)

--- a/spec/factories/dashboard_one_day_amr_readings_factory.rb
+++ b/spec/factories/dashboard_one_day_amr_readings_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     transient do
       association :dashboard_meter, factory: :dashboard_gas_meter
       date          { Date.yesterday }
-      kwh_data_x48  { Array.new(48, rand) }
-      one_day_kwh   { kwh_data_x48.sum }
+      kwh_data_x48  { Array.new(48, rand.to_f) }
+      one_day_kwh   { kwh_data_x48.sum.to_f }
       status        { 'ORIG'}
     end
 

--- a/spec/services/amr/upsert_validated_readings_for_a_meter_spec.rb
+++ b/spec/services/amr/upsert_validated_readings_for_a_meter_spec.rb
@@ -4,7 +4,6 @@ describe Amr::UpsertValidatedReadingsForAMeter do
 
   let(:number_of_readings)    { 2 }
   let(:gas_dashboard_meter)   { build(:dashboard_gas_meter_with_validated_reading, reading_count: number_of_readings) }
-  #let(:elec_dashboard_meter)  { build(:dashboard_electricity_meter_with_validated_reading, reading_count: number_of_readings) }
   let(:upsert_gas_service)    { Amr::UpsertValidatedReadingsForAMeter.new(gas_dashboard_meter) }
 
   describe 'with a validated set of readings' do
@@ -30,7 +29,7 @@ describe Amr::UpsertValidatedReadingsForAMeter do
       Amr::UpsertValidatedReadingsForAMeter.new(gas_dashboard_meter).perform
 
       expect(AmrValidatedReading.count).to be number_of_readings
-      expect(AmrValidatedReading.find_by(reading_date: latest_reading.reading_date).one_day_kwh.to_f).to eq new_total
+      expect(AmrValidatedReading.find_by(reading_date: latest_reading.reading_date).one_day_kwh).to eq BigDecimal(new_total, 15)
     end
   end
 


### PR DESCRIPTION
Tricky to put this on test at the moment, it could go straight to prod if we're happy with the changes - the thing we have to remember is to implement the ordering for the 'new' version of the meter collection factory otherwise this change will be lost.

It also includes removing the upsert gem.