### PR TITLE
Back fill dark sky and solar pv areas

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -30,7 +30,7 @@ files:
         content: |
             10 4 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bundle exec rake data_feeds:dark_sky_back_fill >> log/jobs.log 2>&1'
 
-    "/etc/cron.d/back-fill-any-dark-sky-temperatures":
+    "/etc/cron.d/back-fill-any-solar-pv-readings":
         mode: "000644"
         owner: root
         group: root

--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -23,6 +23,20 @@ files:
         content: |
             45 3 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bundle exec rake data_feeds:dark_sky_temperature_loader >> log/jobs.log 2>&1'
 
+    "/etc/cron.d/back-fill-any-dark-sky-temperatures":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            10 4 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bundle exec rake data_feeds:dark_sky_back_fill >> log/jobs.log 2>&1'
+
+    "/etc/cron.d/back-fill-any-dark-sky-temperatures":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            30 4 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bundle exec rake data_feeds:solar_pv_tuos_back_fill >> log/jobs.log 2>&1'
+
     #
     # Fetch BANES amr files and push to S3
     #

--- a/app/controllers/admin/dark_sky_areas_controller.rb
+++ b/app/controllers/admin/dark_sky_areas_controller.rb
@@ -5,15 +5,12 @@ module Admin
     def index
     end
 
-    def show
-    end
-
     def new
     end
 
     def create
       if @dark_sky_area.save
-        redirect_to admin_dark_sky_areas_path, notice: 'New Dark Sky Area created.'
+        redirect_to admin_dark_sky_areas_path, notice: 'New Dark Sky Area created. Overnight the 4 years of data for this new area will be back filled.'
       else
         render :new
       end

--- a/app/controllers/admin/solar_pv_tuos_areas_controller.rb
+++ b/app/controllers/admin/solar_pv_tuos_areas_controller.rb
@@ -5,9 +5,6 @@ module Admin
     def index
     end
 
-    def show
-    end
-
     def new
     end
 

--- a/app/views/admin/dark_sky_areas/index.html.erb
+++ b/app/views/admin/dark_sky_areas/index.html.erb
@@ -15,7 +15,7 @@
   <tbody>
     <% @dark_sky_areas.each do |dark_sky_area| %>
       <tr>
-        <td><%= link_to dark_sky_area.title, admin_dark_sky_area_path(dark_sky_area) %></td>
+        <td><%= dark_sky_area.title %></td>
         <td><%= dark_sky_area.description %></td>
         <td><%= dark_sky_area.latitude %></td>
         <td><%= dark_sky_area.longitude %></td>

--- a/app/views/admin/solar_pv_tuos_areas/index.html.erb
+++ b/app/views/admin/solar_pv_tuos_areas/index.html.erb
@@ -15,7 +15,7 @@
   <tbody>
     <% @solar_pv_tuos_areas.each do |solar_pv_tuos_area| %>
       <tr>
-        <td><%= link_to solar_pv_tuos_area.title, admin_solar_pv_tuos_area_path(solar_pv_tuos_area) %></td>
+        <td><%= solar_pv_tuos_area.title %></td>
         <td><%= solar_pv_tuos_area.description %></td>
         <td><%= solar_pv_tuos_area.latitude %></td>
         <td><%= solar_pv_tuos_area.longitude %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,8 +157,8 @@ Rails.application.routes.draw do
     resources :activity_types
     resource :activity_type_preview, only: :create
 
-    resources :dark_sky_areas, except: [:destroy]
-    resources :solar_pv_tuos_areas, except: [:destroy]
+    resources :dark_sky_areas, except: [:destroy, :show]
+    resources :solar_pv_tuos_areas, except: [:destroy, :show]
 
     resources :schools, only: [] do
       get :analysis, to: 'analysis#analysis'

--- a/lib/data_feeds/dark_sky_temperature_loader.rb
+++ b/lib/data_feeds/dark_sky_temperature_loader.rb
@@ -44,7 +44,6 @@ module DataFeeds
     end
 
     def process_day(reading_date, temperature_celsius_x48, area)
-      pp "Processing #{reading_date}"
       record = DarkSkyTemperatureReading.find_by(reading_date: reading_date, area_id: area.id)
       if record
         record.update(temperature_celsius_x48: temperature_celsius_x48)

--- a/lib/data_feeds/dark_sky_temperature_loader.rb
+++ b/lib/data_feeds/dark_sky_temperature_loader.rb
@@ -19,6 +19,11 @@ module DataFeeds
       p "Imported #{@insert_count} records, Updated #{@update_count} records"
     end
 
+    def import_area(area)
+      process_area(area)
+      p "Imported #{@insert_count} records, Updated #{@update_count} records"
+    end
+
   private
 
     def process_area(area)
@@ -39,6 +44,7 @@ module DataFeeds
     end
 
     def process_day(reading_date, temperature_celsius_x48, area)
+      pp "Processing #{reading_date}"
       record = DarkSkyTemperatureReading.find_by(reading_date: reading_date, area_id: area.id)
       if record
         record.update(temperature_celsius_x48: temperature_celsius_x48)

--- a/lib/data_feeds/solar_pv_tuos_v2_loader.rb
+++ b/lib/data_feeds/solar_pv_tuos_v2_loader.rb
@@ -17,6 +17,11 @@ module DataFeeds
       p "Imported #{@insert_count} records, Updated #{@update_count} records"
     end
 
+    def import_area(area)
+      process_area(area)
+      p "Imported #{@insert_count} records, Updated #{@update_count} records"
+    end
+
   private
 
     def nearest_gsp_area(area)

--- a/lib/tasks/data_feeds/data_feeds_dark_sky_back_fill.rake
+++ b/lib/tasks/data_feeds/data_feeds_dark_sky_back_fill.rake
@@ -1,0 +1,26 @@
+namespace :data_feeds do
+  desc 'Set up data feeds'
+  task dark_sky_back_fill: :environment do
+
+    MINIMUM_READINGS_PER_YEAR = 365
+    BACK_FILL_YEARS = 4
+
+    DarkSkyArea.all.each do |dark_sky_area|
+      next if dark_sky_area.dark_sky_temperature_readings.count > MINIMUM_READINGS_PER_YEAR * BACK_FILL_YEARS
+
+      BACK_FILL_YEARS.times.each do |year_number|
+        # End date
+        # Year 0 - Date Today
+        # Year 1 - Date Today - 1 year
+        # Year 2 - Date Today - 2 year
+        # Year 3 - Date Today - 3 year
+        end_date = Date.yesterday - (year_number * MINIMUM_READINGS_PER_YEAR)
+        start_date = end_date - MINIMUM_READINGS_PER_YEAR.days
+
+        p "Running #{dark_sky_area.title} for #{start_date} - #{end_date}"
+
+        DataFeeds::DarkSkyTemperatureLoader.new(start_date, end_date).import_area(dark_sky_area)
+      end
+    end
+  end
+end

--- a/lib/tasks/data_feeds/data_feeds_solar_pv_tuos_back_fill.rake
+++ b/lib/tasks/data_feeds/data_feeds_solar_pv_tuos_back_fill.rake
@@ -1,0 +1,28 @@
+namespace :data_feeds do
+  desc 'Set up data feeds'
+  task solar_pv_tuos_back_fill: :environment do
+
+    MINIMUM_READINGS_PER_YEAR = 365
+    BACK_FILL_YEARS = 4
+
+    abort("API Key has not been set") unless ENV['ENERGYSPARKSDARKSKYHISTORICAPIKEY']
+
+    SolarPvTuosArea.all.each do |solar_pv_tuos_area|
+      next if solar_pv_tuos_area.solar_pv_tuos_readings.count > MINIMUM_READINGS_PER_YEAR * BACK_FILL_YEARS
+
+      BACK_FILL_YEARS.times.each do |year_number|
+        # End date
+        # Year 0 - Date Today
+        # Year 1 - Date Today - 1 year
+        # Year 2 - Date Today - 2 year
+        # Year 3 - Date Today - 3 year
+        end_date = Date.yesterday - (year_number * MINIMUM_READINGS_PER_YEAR)
+        start_date = end_date - MINIMUM_READINGS_PER_YEAR.days
+
+        p "Running #{solar_pv_tuos_area.title} for #{start_date} - #{end_date}"
+
+        DataFeeds::SolarPvTuosV2Loader.new(start_date, end_date).import_area(solar_pv_tuos_area)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Simply backfills 4 years worth of data if it's missing - it's not super clever, but does batch into a year per time. If data exists, the loader backfills anyway.